### PR TITLE
Allow usage of router-level error-handling middleware.

### DIFF
--- a/src/models/middleware.ts
+++ b/src/models/middleware.ts
@@ -1,3 +1,6 @@
 import {Request, Response, NextFunction} from 'express';
 
-export type Middleware = (req: Request, res: Response, next: NextFunction) => any;
+export type NormalMiddleware = (req: Request, res: Response, next: NextFunction) => any;
+export type ErrorMiddleware = (err: any, req: Request, res: Response, next: NextFunction) => any;
+
+export type Middleware = NormalMiddleware | ErrorMiddleware;


### PR DESCRIPTION
Allow middlewares which start with a error object.

See https://expressjs.com/en/guide/using-middleware.html#middleware.error-handling
