### PR TITLE
[WIP] Proof of concept for an async/await wrapper around controllers

### DIFF
--- a/src/connect/transfer.ts
+++ b/src/connect/transfer.ts
@@ -1,6 +1,8 @@
-import {Application, Request, Response, NextFunction} from 'express';
-import {Controller} from "../models/controller";
+import {Application} from 'express';
+
+import {Controller} from '../models/controller';
 import {Middleware} from '../models/middleware';
+import {asyncWrapper} from '../util/async_wrapper';
 
 /**
  * Transfer the different methods to the Express application
@@ -17,16 +19,16 @@ export default function transfer(app: Application,
                                  controller: Controller) {
     switch (method) {
         case 'get':
-            app.get(path, middleware, controller);
+            app.get(path, middleware, asyncWrapper(controller));
             break;
         case 'post':
-            app.post(path, middleware, controller);
+            app.post(path, middleware, asyncWrapper(controller));
             break;
         case 'put':
-            app.put(path, middleware, controller);
+            app.put(path, middleware, asyncWrapper(controller));
             break;
         case 'delete':
-            app.delete(path, middleware, controller);
+            app.delete(path, middleware, asyncWrapper(controller));
             break;
         default:
             throw new Error('Unknown method requested for transfer: ' + method);

--- a/src/models/controller.ts
+++ b/src/models/controller.ts
@@ -1,3 +1,3 @@
-import {Request, Response, NextFunction} from 'express';
+import {NextFunction, Request, Response} from 'express';
 
-export type Controller = (req: Request, res: Response, next?: NextFunction) => void;
+export type Controller = (req: Request, res: Response, next?: NextFunction) => void | Promise<void>;

--- a/src/util/async_wrapper.ts
+++ b/src/util/async_wrapper.ts
@@ -1,0 +1,15 @@
+import {NextFunction, Request, Response} from 'express';
+
+import {Controller} from '../models/controller';
+
+export function asyncWrapper(controller: Controller) {
+    return (req: Request, res: Response, next: NextFunction) => {
+
+        const possibleHandlerPromise = controller(req, res, next);
+
+        // Check if we are dealing with a Promise, http://www.ecma-international.org/ecma-262/6.0/#sec-promise.resolve
+        if (Promise.resolve(possibleHandlerPromise) === possibleHandlerPromise) {
+            Promise.resolve(possibleHandlerPromise).catch(next);
+        }
+    };
+}

--- a/tests/torch.test.ts
+++ b/tests/torch.test.ts
@@ -1,7 +1,8 @@
-import {Application, Request, Response, NextFunction} from 'express';
 import {expect} from 'chai';
-import Torch from '../src/torch';
+import {Application, NextFunction, Request, Response} from 'express';
+
 import Router from '../src/router';
+import Torch from '../src/torch';
 
 describe('Torch', function () {
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "outDir": "./build",
+    "lib": ["es2015"],
     "sourceMap": true,
     "moduleResolution": "node",
     "module": "commonjs",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "sourceMap": true,
+    "lib": ["es2015"],
     "moduleResolution": "node",
     "module": "commonjs",
     "target": "es5",


### PR DESCRIPTION
Should work pretty nice this way, some things to concider:

- [ ] Some way of turning this behavior on OR off, probably put it in the route object somewhere, that way we can pass this flat to the `transfer.ts` file from the `connect.ts` filw which has access to the route config
- [ ] Add some documentation
- [ ] Add some tests 
- [ ] Figure out what to do with the failing tests (checking if a method passed to Torch is the same method as it outputs will ofcourse fail it it gets wrapped)
- [ ] Figure out if we want this behavior default or not, currently all it does is check if a controller is a `Promise` and chain it't catch function to the `NextFunction` of express which should catch the `Error` object, still people probably wouldn't expect this behavior?