### PR TITLE
Added context configuration option for routes and groups

### DIFF
--- a/src/connect.ts
+++ b/src/connect.ts
@@ -10,7 +10,9 @@ import {trim} from './util/trim';
 export default function connect(app: Application,
                                 router: Router,
                                 previouxPrefix: string[] = [],
-                                previousMiddleware: Middleware[] = []): Route[] {
+                                previousMiddleware: Middleware[] = [],
+                                currentContext: any = undefined
+                            ): Route[] {
 
     let routes: Route[] = [];
 
@@ -35,13 +37,16 @@ export default function connect(app: Application,
             path = constrain(path, constraints);
         }
 
+        /* Extract context */
+        const context = route.context || currentContext;
+
         /* Transfer to Express */
         transfer(
             app,
             route.method,
             path,
             [...previousMiddleware, ...router.middleware, ...route.middleware],
-            route.controller
+            context ? route.controller.bind(context) : route.controller
         );
 
         /* Add to routes listing */
@@ -57,7 +62,8 @@ export default function connect(app: Application,
             app,
             group,
             prefix,
-            [...previousMiddleware, ...router.middleware]
+            [...previousMiddleware, ...router.middleware],
+            group.context || currentContext
         )];
     });
 

--- a/src/models/group_config.ts
+++ b/src/models/group_config.ts
@@ -4,4 +4,5 @@ import {Middleware} from './middleware';
 export interface GroupConfig {
     middleware?: Middleware[];
     prefix?: string;
+    context?: any;
 }

--- a/src/models/route_config.ts
+++ b/src/models/route_config.ts
@@ -1,10 +1,10 @@
-import {Request, Response, NextFunction} from 'express';
 import {Controller} from './controller';
 import {Middleware} from './middleware';
 
 export interface RouteConfig {
+    controller: Controller;
     method?: string;
     name?: string;
     middleware?: Middleware[];
-    controller: Controller;
+    context?: any;
 }

--- a/src/route.ts
+++ b/src/route.ts
@@ -12,6 +12,8 @@ export default class Route {
 
     private _middleware: Middleware[];
 
+    private _context: any;
+
     private _controller: Controller;
 
     constructor(method: string, path: string, controller: Controller) {
@@ -38,6 +40,14 @@ export default class Route {
 
     set middleware(value: Middleware[]) {
         this._middleware = value;
+    }
+
+    get context(): any {
+        return this._context;
+    }
+
+    set context(value: any) {
+        this._context = value;
     }
 
     get name(): string|undefined {

--- a/src/router.ts
+++ b/src/router.ts
@@ -60,6 +60,14 @@ export default class Router {
     }
 
     /**
+     * Context for routes in this group
+     * @returns {any}
+     */
+    get context(): any {
+        return this._config.context;
+    }
+
+    /**
      * GET method
      * @param path
      * @param config
@@ -146,6 +154,9 @@ export default class Router {
         route.name = config.name;
         if (config.middleware) {
             route.middleware = config.middleware;
+        }
+        if (config.context) {
+            route.context = config.context;
         }
 
         return route;

--- a/tests/torch.test.ts
+++ b/tests/torch.test.ts
@@ -790,4 +790,117 @@ describe('Torch', function () {
             expect(registeredMethod).to.equal(method);
         });
     });
+
+    describe('Binding routes to Express', function() {
+        describe('Context', function () {
+            it('Should be able to define on route level', function () {
+
+                /* Given */
+                type myMetaData = { blaat: string };
+
+                let registeredPath: string|null = null;
+                let registeredMethod: ((req: Request, res: Response) => void)|null = null;
+
+                const app: any = {
+                    get: (path: string, middleware: Array<(req: Request, res: Response, next: NextFunction) => any>, method: ((req: Request, res: Response) => void)) => {
+                        registeredPath = path;
+                        registeredMethod = method;
+                    }
+                };
+
+                class Foo {
+                    private test = 'hello';
+
+                    public method(req: Request, res: Response) {
+                        return this.test;
+                    }
+                }
+                const fooInstance = new Foo();
+
+                /* When */
+                const routes = Torch(app as Application, (router) => {
+                    router.get('/home', {
+                        controller: fooInstance.method,
+                        context: fooInstance
+                    });
+                });
+
+                /* Then */
+                expect(registeredPath).to.equal('/home');
+                expect((registeredMethod as any)(1 as any, 2 as any)).to.equal('hello');
+            });
+            it('Should be able to define at group level', function () {
+
+                /* Given */
+                type myMetaData = { blaat: string };
+
+                let registeredPath: string|null = null;
+                let registeredMethod: ((req: Request, res: Response) => void)|null = null;
+
+                const app: any = {
+                    get: (path: string, middleware: Array<(req: Request, res: Response, next: NextFunction) => any>, method: ((req: Request, res: Response) => void)) => {
+                        registeredPath = path;
+                        registeredMethod = method;
+                    }
+                };
+
+                class Foo {
+                    private test = 'hello';
+
+                    public method(req: Request, res: Response) {
+                        return this.test;
+                    }
+                }
+                const fooInstance = new Foo();
+
+                /* When */
+                const routes = Torch(app as Application, (router) => {
+                    router.group({ context: fooInstance }, (aRouter) => {
+                        aRouter.get('/home', fooInstance.method);
+                    });
+                });
+
+                /* Then */
+                expect(registeredPath).to.equal('/home');
+                expect((registeredMethod as any)(1 as any, 2 as any)).to.equal('hello');
+            });
+            it('Should inherit over groups', function () {
+
+                /* Given */
+                type myMetaData = { blaat: string };
+
+                let registeredPath: string|null = null;
+                let registeredMethod: ((req: Request, res: Response) => void)|null = null;
+
+                const app: any = {
+                    get: (path: string, middleware: Array<(req: Request, res: Response, next: NextFunction) => any>, method: ((req: Request, res: Response) => void)) => {
+                        registeredPath = path;
+                        registeredMethod = method;
+                    }
+                };
+
+                class Foo {
+                    private test = 'hello';
+
+                    public method(req: Request, res: Response) {
+                        return this.test;
+                    }
+                }
+                const fooInstance = new Foo();
+
+                /* When */
+                const routes = Torch(app as Application, (router) => {
+                    router.group({ context: fooInstance }, (aRouter) => {
+                        aRouter.group({ }, (bRouter) => {
+                            bRouter.get('/home', fooInstance.method);
+                        });
+                    });
+                });
+
+                /* Then */
+                expect(registeredPath).to.equal('/home');
+                expect((registeredMethod as any)(1 as any, 2 as any)).to.equal('hello');
+            });
+        });
+    });
 });


### PR DESCRIPTION
It is not possible to maintain context when just passing a method reference from an instance. So we need an argument...

Closes https://github.com/JBlaak/Express-Torch/issues/26